### PR TITLE
Annotations rework

### DIFF
--- a/src/plone/webauthn/key_data.py
+++ b/src/plone/webauthn/key_data.py
@@ -3,7 +3,8 @@ import plone.api
 from zope.annotation.interfaces import IAnnotations
 from BTrees.OOBTree import OOBTree
 
-LOG_KEY = 'plone.webauthn.connector.keydata'
+
+from .webauthn_pas import KEY
 
 class IKeyData(zope.interface.Interface):
     """ Marker interface for User """
@@ -19,10 +20,8 @@ class KeyDataAdapter(object):
 
     @property
     def annotations(self):
-        all_annotations = IAnnotations(self.context)
-        if LOG_KEY not in all_annotations:
-            all_annotations[LOG_KEY] = OOBTree()
-        return all_annotations[LOG_KEY]
+        plugin = plone.api.portal.get().restrictedTraverse("acl_users/Webauthn_helper")
+        return getattr(plugin, KEY)
 
     @property
     def keys(self):

--- a/src/plone/webauthn/key_data.py
+++ b/src/plone/webauthn/key_data.py
@@ -1,6 +1,5 @@
 import zope.interface
 import plone.api
-from zope.annotation.interfaces import IAnnotations
 from BTrees.OOBTree import OOBTree
 
 

--- a/src/plone/webauthn/views/key_management.py
+++ b/src/plone/webauthn/views/key_management.py
@@ -145,13 +145,6 @@ class KeyManagement(BrowserView):
 
         print("registration complete need to add to database.")
 
-        # wrong: self.context = your Plone site
-        # but you want to store the data on the object of the PAS Plugin
-        # import plone.api
-        # data_base = plone.api.portal.get().restrictedTraverse("acl_users/Webauthn_helper")
-        #data_base = IKeyData(plone.api.portal.get().restrictedTraverse("acl_users/Webauthn_helper"))
-        #TypeError: ('Could not adapt', <WebauthnPlugin at /Plone/acl_users/Webauthn_helper>, <InterfaceClass zope.annotation.interfaces.IAnnotations>)
-
         data_base = IKeyData(self.context)
         user_id = str(plone.api.user.get_current())
         cname = self.request["cname"]

--- a/src/plone/webauthn/webauthn_pas.py
+++ b/src/plone/webauthn/webauthn_pas.py
@@ -49,6 +49,7 @@ class WebauthnPlugin(BasePlugin, Cacheable):
     def __init__(self, id, title=None):
         self._setId(id)
         self.title = title
+        annos = self.annotations # ensure that OOBTree is initialized properly
 
     @property
     def annotations(self):

--- a/src/plone/webauthn/webauthn_pas.py
+++ b/src/plone/webauthn/webauthn_pas.py
@@ -10,7 +10,6 @@ from Products.PluggableAuthService.utils import classImplements
 
 import os
 import json
-from .key_data import IKeyData
 
 KEY = "__plone_webauthn"
 
@@ -53,7 +52,6 @@ class WebauthnPlugin(BasePlugin, Cacheable):
 
     @property
     def annotations(self):
-
         annotations = getattr(self, KEY, None)
         if annotations is None:
             setattr(self, KEY, OOBTree())
@@ -68,6 +66,9 @@ class WebauthnPlugin(BasePlugin, Cacheable):
     security.declarePrivate("authenticateCredentials")
     def authenticateCredentials(self, credentials):
         """Find out if the login and password is correct"""
+
+        # function local import for avoid circular imports
+        from .key_data import IKeyData
 
         print(credentials)
         

--- a/src/plone/webauthn/webauthn_pas.py
+++ b/src/plone/webauthn/webauthn_pas.py
@@ -7,13 +7,12 @@ from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlug
 from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
-from zope.annotation.interfaces import IAnnotations
 
 import os
 import json
 from .key_data import IKeyData
 
-KEY = "plone.webauthn.keys"
+KEY = "__plone_webauthn"
 
 
 prefix = os.path.basename(getConfiguration().clienthome)
@@ -54,10 +53,12 @@ class WebauthnPlugin(BasePlugin, Cacheable):
 
     @property
     def annotations(self):
-        all_annotations = IAnnotations(self)
-        if KEY not in all_annotations:
-            all_annotations[KEY] = OOBTree()
-        return all_annotations[KEY]
+
+        annotations = getattr(self, KEY, None)
+        if annotations is None:
+            setattr(self, KEY, OOBTree())
+            annotations = getattr(self, KEY)
+        return annotations
 
     security.declarePrivate("extractCredentials")
     def extractCredentials(self, request):


### PR DESCRIPTION
The implementation of the storage for the keys changed a bit:

- all webauthn related keys are stored on the `acl_users.Webauthn_helper` object inside the private attribute `__plone_webauthn`
- the `annotations()` implemenation in `key_data.py` and `webauthn_pas.py` has been changed accordingly

You need to drop and re-create your Plone site from scratch due to this change.

